### PR TITLE
chore: add support for runtime tracing

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export const DATA_FOLDER = join(ROOT, '.data');
 export const USER_DATA_FOLDER = join(DATA_FOLDER, 'data');
 export const EXTENSIONS_FOLDER = join(DATA_FOLDER, 'extensions');
 export const PERFORMANCE_FILE = join(ROOT, 'startup-perf.txt');
+export const RUNTIME_TRACE_FOLDER = join(ROOT, 'vscode-runtime-traces');
 
 export const PERFORMANCE_RUNS = 10;
 export const VSCODE_DEV_HOST_NAME = 'vscode.dev';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ interface Options extends OptionValues {
 	profAppendTimers?: string;
 	runtime?: string;
 	token?: string;
+	runtimeTraceCategories?: string;
 }
 
 export async function run(options?: Options): Promise<void> {
@@ -38,7 +39,8 @@ export async function run(options?: Options): Promise<void> {
 			.option('-v, --verbose', 'logs verbose output to the console when errors occur')
 			.option('-t, --token <token>', `a GitHub token of scopes 'repo', 'workflow', 'user:email', 'read:user' to enable additional performance tests targetting web`)
 			.addOption(new Option('-r, --runtime <runtime>', 'whether to measure the performance of desktop or web runtime').choices(['desktop', 'web']))
-			.option('--prof-append-timers <prof-append-timers>', 'Measures the time it took to create the workbench and prints it in verbose and pretty format in the passed file. `--duration-markers` and `--duration-markers-file` are ignored when this option is passed.');
+			.option('--prof-append-timers <prof-append-timers>', 'Measures the time it took to create the workbench and prints it in verbose and pretty format in the passed file. `--duration-markers` and `--duration-markers-file` are ignored when this option is passed.')
+			.option('--runtime-trace-categories <runtime-trace-categories>', 'Categories to collect runtime traces. Values can be found in chrome://tracing or edge://tracing');
 
 		options = program.parse(process.argv).opts<Options>();
 	}
@@ -59,6 +61,7 @@ export async function run(options?: Options): Promise<void> {
 			fileToOpen: options.file,
 			profAppendTimers: options.profAppendTimers,
 			token: options.token,
+			runtimeTraceCategories: options.runtimeTraceCategories,
 		});
 	} catch (error) {
 		console.log(`${chalk.red('[error]')} ${error}`);


### PR DESCRIPTION
Adds a new flag `--runtime-trace-categories` which allows to capture chromium trace from the runtime for said categories. Additionally, the traces will be stored at `<vscode-perf-root>/vscode-runtime-traces`.

Example:

```
node .\bin\vscode-perf --build 'C:\Users\demohan\Downloads\VSCode-win32-x64-1.76.0-exploration\bin\code-exploration.cmd' --folder C:\Users\demohan\github\vscode\ --file C:\Users\demohan\github\vscode\package.json --runs 1 --verbose --runtime-trace-categories "benchmark,browser,ipc,loading,navigation,mojom,renderer_host,startup,disabled-by-default-file,disabled-by-default-loading,disabled-by-default-network"
[perf] running session 1 of 1...
[perf] saving chromium trace file at C:\Users\demohan\AppData\Local\Temp\vscode-perf\vscode-runtime-traces\chrometrace_1676029382996.log
[perf] ellapsed: 2086ms (current), 2086ms (fastest), 2086ms (slowest), 2086ms (median)
[perf] Summary:
[perf] ellapsed: 2086ms (fastest), 2086ms (slowest), 2086ms (median)
```