### PR TITLE
feat: enable gpu async channel feature to improve startup

### DIFF
--- a/src/perf.ts
+++ b/src/perf.ts
@@ -138,7 +138,12 @@ async function launchDesktop(options: Options, perfFile: string, markers: string
 		EXTENSIONS_FOLDER,
 		'--disable-extensions',
 		'--disable-workspace-trust',
-		'--disable-features=CalculateNativeWinOcclusion', // disable penalty for occluded windows
+		// Sync channel takes around 1s on modern devices
+		// which is a major contributing factor to startup times
+		// upstream has been working to improve this via an async
+		// channel and it is enabled by default since chromium 134,
+		// Refs https://issues.chromium.org/issues/40208065
+		'--enable-features=EarlyEstablishGpuChannel,EstablishGpuChannelAsync',
 		'--prof-duration-markers-file',
 		perfFile,
 		// disable GPU & sandbox to reduce the chance of flaky


### PR DESCRIPTION
While investigating https://github.com/microsoft/vscode/issues/240767 I see that the renderer main thread is blocked around 1s in establishing the gpu channel. Upstream has finished evaluation of the gpu async channel and has enabled it by default since Chromium 134. Here is the before and after with the feature enabled, `CrRendererMain` is the main thread of the renderer, with the feature enabled we now push the channel to a different thread and free up main thread for other tasks.

***Before:***

[perf] code/willOpenNewWindow-code/willLoadWorkbenchMain: 1295ms (fastest), 1295ms (slowest), 1295ms (median)

![gpu-sync](https://github.com/user-attachments/assets/cb254cd3-8e81-42ee-8720-2f4d07caee64)



***After:***

[perf] code/willOpenNewWindow-code/willLoadWorkbenchMain: 310ms (fastest), 310ms (slowest), 310ms (median)

![gpu-async](https://github.com/user-attachments/assets/5b890e0c-a783-41c0-be8f-ee6cf7eb5a77)
