### PR TITLE
chore: adjust macOS build paths for renamed executable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vscode/vscode-perf",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vscode/vscode-perf",
-            "version": "0.0.25",
+            "version": "0.0.26",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/vscode-perf",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Tooling for evaluating performance of VS Code",
     "repository": {
         "type": "git",

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -77,8 +77,13 @@ function getBuildExecutable(runtime: Runtime, quality: Quality, buildMetadata: I
 		case Runtime.Desktop:
 			switch (platform) {
 				case Platform.MacOSX64:
-				case Platform.MacOSArm:
-					return join(buildPath, buildName, 'Contents', 'MacOS', 'Electron')
+				case Platform.MacOSArm: {
+                    const oldLocation = join(buildPath, buildName, 'Contents', 'MacOS', 'Electron');
+                    if (existsSync(oldLocation)) {
+                        return oldLocation; // only valid until 1.109
+                    }
+                    return join(buildPath, buildName, 'Contents', 'MacOS', quality === Quality.Insider ? 'Code - Insiders' : quality === Quality.Exploration ? 'Code - Exploration' : 'Code');
+                }
 				case Platform.LinuxX64:
 				case Platform.LinuxArm:
 					return join(buildPath, buildName, quality === Quality.Insider ? 'code-insiders' : quality === Quality.Exploration ? `code-exploration` : `code`)


### PR DESCRIPTION
In preparation for https://github.com/microsoft/vscode/pull/291948